### PR TITLE
Fix broken map

### DIFF
--- a/app/assets/config/decidim_homepage_interactive_map_manifest.js
+++ b/app/assets/config/decidim_homepage_interactive_map_manifest.js
@@ -1,2 +1,2 @@
-// = link decidim/homepage_interactive_map/map.js
+// = link decidim/homepage_interactive_map/interactive_map.js
 // = link decidim/homepage_interactive_map/scope.js

--- a/app/assets/config/decidim_homepage_interactive_map_manifest.js
+++ b/app/assets/config/decidim_homepage_interactive_map_manifest.js
@@ -1,2 +1,3 @@
 // = link decidim/homepage_interactive_map/interactive_map.js
+// = link decidim/homepage_interactive_map/interactive_map_without_dependencies.js
 // = link decidim/homepage_interactive_map/scope.js

--- a/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map.js.es6
+++ b/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map.js.es6
@@ -28,7 +28,7 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
   $(document).ready(() => {
     const here_api_key = $("#interactive_map").data("here-api-key");
     const geoJson = $("#interactive_map").data("geojson-data");
-    const popupTemplateId = "marker-popup";
+    const popupTemplateId = "marker-popup-interactive_map";
     $.template(popupTemplateId, $(`#${popupTemplateId}`).html());
 
     // Used to prevent click event when double click navigating
@@ -248,12 +248,14 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
         );
 
         let node = document.createElement("div");
+        console.log(popupTemplateId)
         $.tmpl(popupTemplateId, participatory_process).appendTo(node);
+          console.log(node)
         marker.bindPopup(node, {
           maxwidth: popupMaxwidth(),
           minWidth: popupMinwidth(),
           keepInView: true,
-          className: "map-info"
+          className: "interactive-map-info"
         }).openPopup();
 
         marker.participatory_process_data = participatory_process;

--- a/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map.js.es6
+++ b/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map.js.es6
@@ -98,13 +98,17 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
     }
 
     function updateProcessMarkerPosition(marker, delta, zoom) {
-      let oldPoint = map.project(L.latLng(marker.origin), zoom);
+        let oldPoint = map.project(L.latLng(marker.origin), zoom);
+
       let radius = ( delta / 2 ) + ( marker.getRadius() / 1.75 ) ;
       let newPoint = L.point(
         oldPoint.x + ( radius * Math.cos( Math.PI / 4 ) ),
         oldPoint.y - ( radius * Math.sin( Math.PI / 4 ) )
       );
-      marker.setLatLng(map.unproject(newPoint, zoom));
+
+      // TODO: setLatLng method can occur error
+      marker._latlng = map.unproject(newPoint, zoom);
+      //marker.setLatLng(map.unproject(newPoint, zoom));
     }
 
     function calculateIconSize() {

--- a/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map_without_dependencies.js.es6
+++ b/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map_without_dependencies.js.es6
@@ -94,15 +94,16 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
     }
 
     function updateProcessMarkerPosition(marker, delta, zoom) {
-        // TODO: When there is multiple maps on homepage, this function can't fetch the lat and long
-      return;
       let oldPoint = interactiveMap.project(L.latLng(marker.origin), zoom);
       let radius = ( delta / 2 ) + ( marker.getRadius() / 1.75 ) ;
       let newPoint = L.point(
         oldPoint.x + ( radius * Math.cos( Math.PI / 4 ) ),
         oldPoint.y - ( radius * Math.sin( Math.PI / 4 ) )
       );
-      marker.setLatLng(interactiveMap.unproject(newPoint, zoom));
+
+        marker._latlng = interactiveMap.unproject(newPoint, zoom);
+        // TODO: Check why setLatLng causes a JS error
+//        marker.setLatLng(interactiveMap.unproject(newPoint, zoom));
     }
 
     function calculateIconSize() {

--- a/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map_without_dependencies.js.es6
+++ b/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map_without_dependencies.js.es6
@@ -4,7 +4,6 @@
 // = require leaflet.markercluster
 // = require proj4
 // = require proj4leaflet
-// = require jquery-tmpl
 // = require leaflet-polylabel-centroid
 // = require_self
 

--- a/app/cells/decidim/homepage_interactive_map/content_blocks/interactive_map/show.erb
+++ b/app/cells/decidim/homepage_interactive_map/content_blocks/interactive_map/show.erb
@@ -3,7 +3,7 @@
     <section class="extended home-section" id="homepage_map">
       <div class="wrapper-home">
         <%= interactive_map_for(assemblies_data_for_map(@geolocalized_assemblies)) do %>
-          <template id="marker-popup">
+          <template id="marker-popup-interactive_map">
             <div class="map-info__content homepage_interactive_map">
               <h3>${title}</h3>
               <div id="bodyContent">
@@ -20,7 +20,6 @@
               </div>
             </div>
           </template>
-          <%= javascript_include_tag "decidim/homepage_interactive_map/map" %>
           <%= stylesheet_link_tag "decidim/map" %>
           <%= stylesheet_link_tag "decidim/homepage_interactive_map/map" %>
         <% end %>

--- a/app/views/decidim/homepage/show.html.erb
+++ b/app/views/decidim/homepage/show.html.erb
@@ -1,0 +1,20 @@
+<%
+  edit_link(
+      decidim_admin.edit_organization_path,
+      :update,
+      :organization,
+      organization: current_organization
+  )
+%>
+
+<% content_blocks = Decidim::ContentBlock.published.for_scope(:homepage, organization: current_organization) %>
+
+<% content_blocks.each do |content_block| %>
+  <% next unless content_block.manifest %>
+
+  <%= cell content_block.manifest.cell, content_block %>
+<% end %>
+
+<% if content_blocks.map(&:manifest_name).include? "interactive_map" %>
+  <%= javascript_include_tag "decidim/homepage_interactive_map/interactive_map" %>
+<% end %>

--- a/app/views/decidim/homepage/show.html.erb
+++ b/app/views/decidim/homepage/show.html.erb
@@ -15,6 +15,10 @@
   <%= cell content_block.manifest.cell, content_block %>
 <% end %>
 
-<% if content_blocks.map(&:manifest_name).include? "interactive_map" %>
-  <%= javascript_include_tag "decidim/homepage_interactive_map/interactive_map" %>
-<% end %>
+<%=
+  if content_blocks.map(&:manifest_name).include?("interactive_map") && content_blocks.map(&:manifest_name).include?("upcoming_events")
+    javascript_include_tag "decidim/homepage_interactive_map/interactive_map_without_dependencies"
+  elsif content_blocks.map(&:manifest_name).include?("interactive_map")
+    javascript_include_tag "decidim/homepage_interactive_map/interactive_map"
+  end
+%>


### PR DESCRIPTION
#### What? Why?

We found a compatibility issue between content blocks when there is several maps. 

#### Explanation :

When the content block `upcoming events` is enabled, it loads the `map.js` script in `decidim-core` and requires leaflet. However the content block `interactive_map` also needs leaflet and proj4leaflet to customize the global variable `L`.

We had to find a solution for loading those two content blocks without break the maps. Furthermore, labels have a bad content when multiple maps are loaded because each scripts loads `jquery-tmpl` script. 