### PR TITLE
avoid map container js error

### DIFF
--- a/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map.js.es6
+++ b/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map.js.es6
@@ -29,6 +29,11 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
     const here_api_key = $("#interactive_map").data("here-api-key");
     const geoJson = $("#interactive_map").data("geojson-data");
     const popupInteractiveTemplateId = "marker-popup-interactive_map";
+
+    if (here_api_key === undefined && geoJson === undefined) {
+      return;
+    }
+
     $.template(popupInteractiveTemplateId, $(`#${popupInteractiveTemplateId}`).html());
 
     // Used to prevent click event when double click navigating

--- a/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map_without_dependencies.js.es6
+++ b/app/assets/javascripts/decidim/homepage_interactive_map/interactive_map_without_dependencies.js.es6
@@ -25,6 +25,11 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
     const here_api_key = $("#interactive_map").data("here-api-key");
     const geoJson = $("#interactive_map").data("geojson-data");
     const popupInteractiveTemplateId = "marker-popup-interactive_map";
+
+    if (here_api_key === undefined && geoJson === undefined) {
+      return;
+    }
+
     $.template(popupInteractiveTemplateId, $(`#${popupInteractiveTemplateId}`).html());
 
     // Used to prevent click event when double click navigating


### PR DESCRIPTION
Avoid JS error `Map container not found`

#### Context
When there is no geolocalized assemblies, js script try to work with undefined HTML element
