### PR TITLE
[Fix] - Marker position on geocoded PP

### DIFF
--- a/app/packs/src/decidim/homepage_interactive_map/interactive_map.js
+++ b/app/packs/src/decidim/homepage_interactive_map/interactive_map.js
@@ -326,11 +326,9 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
       });
 
 
-      // Translate the marker centered on the zone outside the zone label
-      // ( like an notification badge )
-      if(!hasLocation(marker.participatory_process_data)) {
+
         updateProcessMarkerPosition(marker, iconSize, map.getZoom());
-      }
+
     });
 
 
@@ -356,9 +354,7 @@ L.DivIcon.SVGIcon.DecidimIcon = L.DivIcon.SVGIcon.extend({
       });
 
       allProcessesLayer.eachLayer((marker) => {
-        if(!hasLocation(marker.participatory_process_data)) {
-          updateProcessMarkerPosition(marker, actualIconSize, map.getZoom());
-        }
+        updateProcessMarkerPosition(marker, actualIconSize, map.getZoom());
       });
 
       allProcessesLayer.refreshClusters();

--- a/db/module_seeds.rb
+++ b/db/module_seeds.rb
@@ -36,6 +36,9 @@ last_participatory_process = Decidim::ParticipatoryProcess.last
 
 first_participatory_process.update!(display_linked_assemblies: true)
 last_participatory_process.update!(display_linked_assemblies: true)
+last_participatory_process.update!(address: "Rue de la Fayette")
+last_participatory_process.update!(latitude: 43.604429)
+last_participatory_process.update!(longitude: 1.443812)
 
 puts "-- Linking Participatory processes to Assemblies"
 Decidim::ParticipatorySpaceLink.create!(


### PR DESCRIPTION
#### Description

When a PP is geocoded, marker takes the position of the PP rather than being placed on the top right corner of the PP marker.

#### PR's behaviour

Now markers on geocoded PP are placed on the top right corner

- [x] Update seeds to have a geocoded PP and not geocoded PP