### PR TITLE
fix: Handle GeoJSON FeatureCollection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
       - uses: codecov/codecov-action@v1
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/app/forms/decidim/admin/scope_form.rb
+++ b/app/forms/decidim/admin/scope_form.rb
@@ -15,7 +15,7 @@ module Decidim
       attribute :geolocalized, Boolean
       jsonb_attribute :geojson, [
         [:geometry, String],
-        [:parsed_geometry, String],
+        [:parsed_geometry, Hash],
         [:color, String]
       ]
 
@@ -49,7 +49,14 @@ module Decidim
         return true if geolocalized.blank?
 
         begin
-          self.parsed_geometry = JSON.parse(geometry)
+          self.parsed_geometry = JSON.parse(geometry).deep_symbolize_keys
+          if parsed_geometry[:type] == "FeatureCollection"
+            if parsed_geometry[:features].present? && parsed_geometry[:features].size > 1
+              errors.add(:geometry, "GeoJSON error : FeatureCollection with more than one feature are not valid")
+            else
+              self.parsed_geometry = parsed_geometry[:features]&.first
+            end
+          end
         rescue StandardError
           errors.add(:geometry, I18n.t("decidim.scope.errors.geojson_error"))
         end


### PR DESCRIPTION
- fix `geojson[:parsed_geometry] `sub type (String -> Hash)
- if GeoJSON is a `FeatureCollection` at one feature then we use only that feature and not collection